### PR TITLE
Add check for missing conversation_state

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -238,6 +238,10 @@ def main(file_path):
         LOG_INFO('Parsing JSON file: {}'.format(file_path))
         json_archive = json.load(f)
 
+        if not 'conversation_state' in json_archive.keys():
+            LOG_ERROR('Could not find `conversation_state` in file {}'.format(file_path))
+            return
+
         # Parse each conversation
         for state in json_archive['conversation_state']:
             conv = Conversation(state)


### PR DESCRIPTION
Resolves issue in #1 by checking for `conversation_state` before indexing. Unfortunately without it, we can't really parse, so we just exit cleanly. I don't have any `Hangouts.json` files that are missing `conversation_state` so I can't test it, but it should work unless my python is super rusty 😅 